### PR TITLE
fix: improve :where support on safari ios

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -103,6 +103,17 @@ const SINGLE_COLON_PSEUDO_ELEMENTS = new Set([
   'first-letter',
 ]);
 
+function isWherePseudoClassSupported(): boolean {
+  try {
+    // Cannot rely on CSS.supports('selector(:where(div))')
+    // since it's not supported on Safari iOS < 14.5
+    document.querySelector(':where(div)');
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
 function transformContainerDimensions(node: DimensionToken): Node {
   const name = node.unit;
   const variable = CUSTOM_UNIT_MAP[name];
@@ -379,7 +390,7 @@ function transformSelector(
     }
 
     if (IS_WPT_BUILD) {
-      if (!SUPPORTS_WHERE_PSEUDO_CLASS) {
+      if (!isWherePseudoClassSupported()) {
         targetSelector.push(...NO_WHERE_SELECTOR_TOKENS);
       }
     }
@@ -407,7 +418,7 @@ function transformSelector(
       },
     ];
 
-    if (!SUPPORTS_WHERE_PSEUDO_CLASS) {
+    if (!isWherePseudoClassSupported()) {
       const actual = targetSelector.map(serialize).join('');
       if (!actual.endsWith(NO_WHERE_SELECTOR)) {
         invalidSelectorCallback({


### PR DESCRIPTION
Fix an issue where the polyfill is not working on iOS Safari versions below 14.5. It leads to the container queries being ignored and the style being applied regardless of the container query conditions.

The check for the `:where()` support on these iOS versions below 14.5 is returning `false` even though it should be supported from Safari 14.0 (from what we can see on [caniuse](https://caniuse.com/mdn-css_selectors_where)). This leads to the style breaking and we can also see the warnings in the console. It seems that `CSS.supports()` for selectors is not working.

<img width="290" alt="image" src="https://github.com/GoogleChromeLabs/container-query-polyfill/assets/779096/e85c0059-2370-4871-b797-872bfdea2cf9">. 
(Screenshot taken from lambdatest on an iPhone 12 Pro Safari iOS 14.1)

    
I replaced this check by checking for `document.querySelector(':where(div)');` instead in a try catch which seems to fix the issue. 

To be noted, the issue is not happening on macOS, I could reproduce the issue only on iPhones and iPad.

Could be related to https://github.com/GoogleChromeLabs/container-query-polyfill/issues/80


